### PR TITLE
feat: integrate YouTube Data API v3 with fallback to hardcoded data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# YouTube Data API v3
+# Get your API key from: https://console.cloud.google.com
+# Enable "YouTube Data API v3" in the API library
+YOUTUBE_API_KEY=
+
+# Your YouTube channel ID (found in youtube.com/channel/<id> or channel settings)
+YOUTUBE_CHANNEL_ID=
+
+# Secondary YouTube channel ID for vlogs (if different from above)
+YOUTUBE_VLOGS_CHANNEL_ID=
+
+# Spotify Web API (Issue #21)
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Instagram Graph API (Issue #22)
+INSTAGRAM_ACCESS_TOKEN=
+INSTAGRAM_USER_ID=

--- a/app/music/page.tsx
+++ b/app/music/page.tsx
@@ -1,14 +1,20 @@
 import MediaScroll from "@/components/music/MediaScroll";
 import StatsPanel from "@/components/music/StatsPanel";
 import music from "@/data/music";
+import { getLiveMusicStats, getLiveMusicYouTubeItems } from "@/lib/youtube";
 
-export default function MusicPage() {
+export default async function MusicPage() {
+  const [stats, items] = await Promise.all([
+    getLiveMusicStats(music.stats),
+    getLiveMusicYouTubeItems(music.items),
+  ]);
+
   return (
     <main className="flex flex-row flex-1 bg-zinc-50 dark:bg-black">
       <div className="flex-1 overflow-hidden">
-        <MediaScroll />
+        <MediaScroll items={items} />
       </div>
-      <StatsPanel stats={music.stats} />
+      <StatsPanel stats={stats} />
     </main>
   );
 }

--- a/app/vlogs/page.tsx
+++ b/app/vlogs/page.tsx
@@ -1,14 +1,20 @@
 import VlogScroll from "@/components/vlogs/VlogScroll";
 import VlogStatsPanel from "@/components/vlogs/VlogStatsPanel";
 import vlogs from "@/data/vlogs";
+import { getLiveVlogStats, getLiveVlogItems } from "@/lib/youtube";
 
-export default function VlogsPage() {
+export default async function VlogsPage() {
+  const [stats, items] = await Promise.all([
+    getLiveVlogStats(vlogs.stats),
+    getLiveVlogItems(vlogs.items),
+  ]);
+
   return (
     <main className="flex flex-row flex-1 bg-zinc-50 dark:bg-black">
       <div className="flex-1 overflow-hidden">
-        <VlogScroll />
+        <VlogScroll items={items} />
       </div>
-      <VlogStatsPanel stats={vlogs.stats} />
+      <VlogStatsPanel stats={stats} />
     </main>
   );
 }

--- a/components/music/MediaScroll.tsx
+++ b/components/music/MediaScroll.tsx
@@ -1,10 +1,10 @@
-import music from "@/data/music";
+import { MusicItem } from "@/data/music";
 import MediaCard from "./MediaCard";
 
-export default function MediaScroll() {
+export default function MediaScroll({ items }: { items: MusicItem[] }) {
   return (
     <div className="flex flex-row overflow-x-auto gap-4 p-4">
-      {music.items.map((item) => (
+      {items.map((item) => (
         <MediaCard key={item.embedId} {...item} />
       ))}
     </div>

--- a/components/vlogs/VlogScroll.tsx
+++ b/components/vlogs/VlogScroll.tsx
@@ -1,10 +1,10 @@
-import vlogs from "@/data/vlogs";
+import { VlogItem } from "@/data/vlogs";
 import VlogCard from "./VlogCard";
 
-export default function VlogScroll() {
+export default function VlogScroll({ items }: { items: VlogItem[] }) {
   return (
     <div className="flex flex-col overflow-y-auto gap-4 p-4">
-      {vlogs.items.map((item) => (
+      {items.map((item) => (
         <VlogCard key={item.youtubeId} {...item} />
       ))}
     </div>

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,0 +1,114 @@
+import { MusicItem, MusicStats } from "@/data/music";
+import { VlogItem, VlogStats } from "@/data/vlogs";
+
+const BASE_URL = "https://www.googleapis.com/youtube/v3";
+
+export async function getChannelStats(
+  channelId: string
+): Promise<{ ytSubscribers: number; totalViews: number } | null> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey || !channelId) return null;
+
+  try {
+    const res = await fetch(
+      `${BASE_URL}/channels?part=statistics&id=${channelId}&key=${apiKey}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const stats = data.items?.[0]?.statistics;
+    if (!stats) return null;
+
+    return {
+      ytSubscribers: parseInt(stats.subscriberCount ?? "0", 10),
+      totalViews: parseInt(stats.viewCount ?? "0", 10),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function getRecentVideos(
+  channelId: string,
+  limit = 5
+): Promise<{ embedId: string; title: string }[] | null> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey || !channelId) return null;
+
+  try {
+    const res = await fetch(
+      `${BASE_URL}/search?part=snippet&channelId=${channelId}&order=date&maxResults=${limit}&type=video&key=${apiKey}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    return (
+      data.items?.map(
+        (item: { id: { videoId: string }; snippet: { title: string } }) => ({
+          embedId: item.id.videoId,
+          title: item.snippet.title,
+        })
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+export async function getLiveMusicStats(
+  fallback: MusicStats
+): Promise<MusicStats> {
+  const channelId = process.env.YOUTUBE_CHANNEL_ID ?? "";
+  const live = await getChannelStats(channelId);
+  if (!live) return fallback;
+  return { ...fallback, ytSubscribers: live.ytSubscribers };
+}
+
+export async function getLiveMusicYouTubeItems(
+  fallback: MusicItem[]
+): Promise<MusicItem[]> {
+  const channelId = process.env.YOUTUBE_CHANNEL_ID ?? "";
+  const videos = await getRecentVideos(channelId, 5);
+  if (!videos) return fallback;
+
+  const liveItems: MusicItem[] = videos.map((v) => ({
+    type: "youtube",
+    embedId: v.embedId,
+    title: v.title,
+  }));
+
+  // Keep non-youtube items (spotify, instagram) from the fallback
+  const otherItems = fallback.filter((item) => item.type !== "youtube");
+  return [...liveItems, ...otherItems];
+}
+
+export async function getLiveVlogStats(
+  fallback: VlogStats
+): Promise<VlogStats> {
+  const channelId =
+    process.env.YOUTUBE_VLOGS_CHANNEL_ID ??
+    process.env.YOUTUBE_CHANNEL_ID ??
+    "";
+  const live = await getChannelStats(channelId);
+  if (!live) return fallback;
+  return { ytSubscribers: live.ytSubscribers, totalViews: live.totalViews };
+}
+
+export async function getLiveVlogItems(
+  fallback: VlogItem[]
+): Promise<VlogItem[]> {
+  const channelId =
+    process.env.YOUTUBE_VLOGS_CHANNEL_ID ??
+    process.env.YOUTUBE_CHANNEL_ID ??
+    "";
+  const videos = await getRecentVideos(channelId, 10);
+  if (!videos) return fallback;
+
+  return videos.map((v) => ({
+    youtubeId: v.embedId,
+    title: v.title,
+    channel: process.env.YOUTUBE_VLOGS_CHANNEL_ID ? "secondary" : "main",
+  }));
+}


### PR DESCRIPTION
## Summary
- Creates `lib/youtube.ts` with `getChannelStats` and `getRecentVideos` fetching from YouTube Data API v3, with 1hr revalidation via Next.js fetch cache
- Adds `.env.example` documenting all API keys (current + future Spotify/Instagram)
- Updates `app/music/page.tsx` and `app/vlogs/page.tsx` to async Server Components that fetch live data
- Refactors `MediaScroll` and `VlogScroll` to accept `items` as props (instead of importing data directly)
- Graceful fallback to hardcoded data in `data/music.ts` / `data/vlogs.ts` if API key is missing or request fails

## Setup
Copy `.env.example` to `.env.local` and fill in:
```
YOUTUBE_API_KEY=your_key_here
YOUTUBE_CHANNEL_ID=UCxxxxxxxxx
YOUTUBE_VLOGS_CHANNEL_ID=UCxxxxxxxxx  # if different channel for vlogs
```

## Files affected
- `lib/youtube.ts` (created)
- `.env.example` (created)
- `components/music/MediaScroll.tsx` (accepts `items` prop)
- `components/vlogs/VlogScroll.tsx` (accepts `items` prop)
- `app/music/page.tsx` (async, fetches live data)
- `app/vlogs/page.tsx` (async, fetches live data)

Closes #20